### PR TITLE
Attempt to read width from a custom environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 cli-width
 =========
 
-Get stdout window width, with two fallbacks, `tty` and then a default.
+Get stdout window width, with three fallbacks, `tty`, a custom environment variable and then a default.
 
 ## Usage
 
@@ -16,6 +16,8 @@ var cliWidth = require('cli-width');
 
 cliWidth(); // maybe 204 :)
 ```
+
+You can also set the `CLI_WIDTH` environment variable.
 
 If none of the methods are supported, the default is `0` and
 can be changed via `cliWidth.defaultWidth = 200;`.

--- a/index.js
+++ b/index.js
@@ -14,6 +14,14 @@ function cliWidth() {
       return tty.getWindowSize()[1];
     }
     else {
+      if (process.env.CLI_WIDTH) {
+        var width = parseInt(process.env.CLI_WIDTH, 10);
+
+        if (!isNaN(width)) {
+          return width;
+        }
+      }
+
       return exports.defaultWidth;
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,25 @@ test('uses tty.getWindowSize', function (t) {
   t.end();
 });
 
+test('uses custom env var', function (t) {
+  tty.getWindowSize = undefined;
+  process.env.CLI_WIDTH = 30;
+
+  t.equal(lib(), 30, 'equal to mocked, 30');
+
+  delete process.env.CLI_WIDTH;
+  t.end();
+});
+
+test('uses default if env var is not a number', function (t) {
+  process.env.CLI_WIDTH = 'foo';
+
+  t.equal(lib(), 0, 'default unset value, 0');
+
+  delete process.env.CLI_WIDTH;
+  t.end();
+});
+
 test('uses default', function (t) {
   tty.getWindowSize = undefined;
 


### PR DESCRIPTION
This proves to be handy for processes to share their `cli-width` with
their children process, who by default get a value of zero otherwise.

Example:

``` js
var child_process = require('child_process');
var cliWidth = require('cli-width');

child_process.spawn('node', [ 'foo.js'  ], {
  env: {
    CLI_WIDTH: cliWidth()
  }
});
```

Implements: https://github.com/knownasilya/cli-width/issues/4
