### PR TITLE
alpine reports a width of 0 for process.stdout.getWindowSize[0]

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,13 @@ exports.defaultWidth = 0;
 
 function cliWidth() {
   if (process.stdout.getWindowSize) {
-    return process.stdout.getWindowSize()[0];
+    return process.stdout.getWindowSize()[0] || exports.defaultWidth;
   }
   else {
     var tty = require('tty');
 
     if (tty.getWindowSize) {
-      return tty.getWindowSize()[1];
+      return tty.getWindowSize()[1] || exports.defaultWidth;
     }
     else {
       if (process.env.CLI_WIDTH) {

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,17 @@ test('uses process.stdout.getWindowSize', function (t) {
   t.end();
 });
 
+test('uses default if process.stdout.getWindowSize reports width of 0', function (t) {
+  lib.defaultWidth = 10;
+  process.stdout.getWindowSize = function () {
+    return [0];
+  };
+
+  t.equal(lib(), 10, 'equal to mocked, 10');
+  lib.defaultWidth = 0; // set default back to original value.
+  t.end();
+})
+
 test('uses tty.getWindowSize', function (t) {
   process.stdout.getWindowSize = undefined;
   tty.getWindowSize = function () {
@@ -24,6 +35,18 @@ test('uses tty.getWindowSize', function (t) {
   t.equal(lib(), 5, 'equal to mocked, 5');
   t.end();
 });
+
+test('uses default if tty.getWindowSize reports width of 0', function (t) {
+  lib.defaultWidth = 10;
+  process.stdout.getWindowSize = undefined;
+  tty.getWindowSize = function () {
+    return [0, 0];
+  };
+
+  t.equal(lib(), 10, 'equal to mocked, 10');
+  lib.defaultWidth = 0; // set default back to original value.
+  t.end();
+})
 
 test('uses custom env var', function (t) {
   tty.getWindowSize = undefined;


### PR DESCRIPTION
When running through `docker exec` the Alpine OS reports `process.stdout.getWindowSize[0] = 0`, this in turn breaks the upstream inquirer dependency like so:

https://gist.github.com/bcoe/6bc16d0dbe5190b8d302

It seems appropriate to instead use the default value if a terminal width of 0 is reported.
