### PR TITLE
Added fourth fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 cli-width
 =========
 
-Get stdout window width, with three fallbacks, `tty`, a custom environment variable and then a default.
+Get stdout window width, with four fallbacks, `tty`, a custom environment variable and then a default.
 
 [![npm version](https://badge.fury.io/js/cli-width.svg)](http://badge.fury.io/js/cli-width)
 [![Build Status](https://travis-ci.org/knownasilya/cli-width.svg)](https://travis-ci.org/knownasilya/cli-width)

--- a/index.js
+++ b/index.js
@@ -30,11 +30,16 @@ function cliWidth(options) {
       return opts.tty.getWindowSize()[1] || opts.defaultWidth;
     }
     else {
-      if (process.env.CLI_WIDTH) {
-        var width = parseInt(process.env.CLI_WIDTH, 10);
+      if (opts.output.columns) {
+        return opts.output.columns;
+      }
+      else {
+        if (process.env.CLI_WIDTH) {
+          var width = parseInt(process.env.CLI_WIDTH, 10);
 
-        if (!isNaN(width)) {
-          return width;
+          if (!isNaN(width)) {
+            return width;
+          }
         }
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -45,33 +45,48 @@ test('uses default if tty.getWindowSize reports width of 0', function (t) {
 })
 
 test('uses custom env var', function (t) {
+  var oldWidth = process.stdout.columns;
+  process.stdout.columns = undefined;
   tty.getWindowSize = undefined;
   process.env.CLI_WIDTH = 30;
 
   t.equal(lib(), 30, 'equal to mocked, 30');
 
   delete process.env.CLI_WIDTH;
+  process.stdout.columns = oldWidth;
   t.end();
 });
 
 test('uses default if env var is not a number', function (t) {
+  var oldWidth = process.stdout.columns;
+  process.stdout.columns = undefined;
   process.env.CLI_WIDTH = 'foo';
 
   t.equal(lib(), 0, 'default unset value, 0');
 
   delete process.env.CLI_WIDTH;
+  process.stdout.columns = oldWidth;
   t.end();
 });
 
 test('uses default', function (t) {
+  var oldWidth = process.stdout.columns;
+  process.stdout.columns = undefined;
   tty.getWindowSize = undefined;
 
   t.equal(lib(), 0, 'default unset value, 0');
+
+  process.stdout.columns = oldWidth;
   t.end();
 });
 
 test('uses overridden default', function (t) {
+  var oldWidth = process.stdout.columns;
+  process.stdout.columns = undefined;
+
   t.equal(lib({ defaultWidth: 10 }), 10, 'user-set defaultWidth value, 10');
+
+  process.stdout.columns = oldWidth;
   t.end();
 });
 
@@ -81,7 +96,9 @@ test('uses user-configured output stream', function (t) {
           return [10];
       }
   };
+
   t.equal(lib({ output: outputMock }), 10, 'user-set output stream, 10');
+
   t.end();
 });
 
@@ -91,6 +108,20 @@ test('uses user-configured tty', function (t) {
           return [2, 5];
       }
   };
+
   t.equal(lib({ tty: ttyMock }), 5, 'user-set tty, 5');
+
   t.end();
 });
+
+test('uses output.columns', function (t) {
+  var oldWidth = process.stdout.columns;
+  process.stdout.columns = 15;
+  process.stdout.getWindowSize = undefined;
+  delete process.env.CLI_WIDTH;
+
+  t.equal(lib({ output: process.stdout }), 15, 'user-set output, 15');
+
+  process.stdout.columns = oldWidth;
+  t.end();
+})


### PR DESCRIPTION
Added a fallback checking the value of `opts.output.columns` before using `process.env.CLI_WIDTH`.
