### PR TITLE
Add Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for cli-width 4.0
+/// <reference types="node" />
+
+import { Stream } from 'stream';
+import tty = require('tty');
+
+declare function cliWidth(options?: {
+  defaultWidth?: number;
+  output?: Stream;
+  tty?: typeof tty;
+}): number;
+
+export = cliWidth;

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
     "node": "12.22.11",
     "npm": "8.5.5"
   },
-  "files": ["index.js"]
+  "files": ["index.js", "index.d.ts"]
 }


### PR DESCRIPTION
Little addition to make it easier to use within TS projects.

The API surface is small enough (and the package simple enough), that I feel just a `.d.ts` is good enough and should be simple to maintain.

Side note: I have rights to the npm package, but not the github repository. It'd be great to have both so I can make release with the source code (not sure how active you are within OSS nowadays.)